### PR TITLE
Make paths in test code platform independent

### DIFF
--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -38,8 +38,6 @@ def sample_convert_string_to_int(string_to_convert: str) -> Union[int, None]:
 
 
 cwd = pathlib.Path.cwd()
-while os.path.basename(cwd) != constants.PROJECT_NAME:
-    cwd = cwd.parent
 
 
 def test_if_tracer_is_initialized_with_invalid_values_error_is_raised():
@@ -57,7 +55,7 @@ def test_if_tracer_traces_sample_function_which_raises_error_it_collects_correct
     none_type = type(None)
 
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_convert_string_to_int",
         32,
         TraceDataCategory.FUNCTION_ARGUMENT,
@@ -65,7 +63,7 @@ def test_if_tracer_traces_sample_function_which_raises_error_it_collects_correct
         string_type,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_convert_string_to_int",
         37,
         TraceDataCategory.FUNCTION_RETURN,
@@ -92,7 +90,7 @@ def test_if_tracer_traces_sample_function_it_collects_correct_tracing_data():
     btype = type(False)
 
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_compare_integers",
         22,
         TraceDataCategory.FUNCTION_ARGUMENT,
@@ -100,7 +98,7 @@ def test_if_tracer_traces_sample_function_it_collects_correct_tracing_data():
         itype,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_compare_integers",
         22,
         TraceDataCategory.FUNCTION_ARGUMENT,
@@ -108,7 +106,7 @@ def test_if_tracer_traces_sample_function_it_collects_correct_tracing_data():
         itype,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_compare_integers",
         24,
         TraceDataCategory.LOCAL_VARIABLE,
@@ -116,7 +114,7 @@ def test_if_tracer_traces_sample_function_it_collects_correct_tracing_data():
         btype,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_compare_integers",
         24,
         TraceDataCategory.FUNCTION_RETURN,
@@ -141,7 +139,7 @@ def test_if_tracer_traces_sample_function_which_defines_multiple_variables_in_on
     tuple_type = type((int_type, string_type))
 
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_get_two_variables_declared_in_one_line",
         29,
         TraceDataCategory.LOCAL_VARIABLE,
@@ -149,7 +147,7 @@ def test_if_tracer_traces_sample_function_which_defines_multiple_variables_in_on
         int_type,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_get_two_variables_declared_in_one_line",
         29,
         TraceDataCategory.LOCAL_VARIABLE,
@@ -157,7 +155,7 @@ def test_if_tracer_traces_sample_function_which_defines_multiple_variables_in_on
         string_type,
     ]
     expected_trace_data.loc[len(expected_trace_data.index)] = [
-        "tests/test_tracer.py",
+        str(pathlib.Path("tests", "test_tracer.py")),
         "sample_get_two_variables_declared_in_one_line",
         29,
         TraceDataCategory.FUNCTION_RETURN,
@@ -185,45 +183,94 @@ def test_if_tracer_traces_sample_function_with_inner_function_it_collects_correc
     int_type = type(1)
     bool_type = type(True)
 
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists', 10,
-                                                               TraceDataCategory.FUNCTION_ARGUMENT, 'list1', list_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists', 10,
-                                                               TraceDataCategory.FUNCTION_ARGUMENT,
-                                                               'list2', list_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists',
-                                                               15,
-                                                               TraceDataCategory.LOCAL_VARIABLE,
-                                                               'i', int_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists',
-                                                               15,
-                                                               TraceDataCategory.LOCAL_VARIABLE,
-                                                               'element1', int_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists', 16,
-                                                               TraceDataCategory.LOCAL_VARIABLE,
-                                                               'element2', int_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_integers', 22,
-                                                               TraceDataCategory.FUNCTION_ARGUMENT,
-                                                               'value1', int_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_integers',
-                                                               22,
-                                                               TraceDataCategory.FUNCTION_ARGUMENT,
-                                                               'value2', int_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_integers',
-                                                               24,
-                                                               TraceDataCategory.LOCAL_VARIABLE,
-                                                               'result', bool_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_integers',
-                                                               24,
-                                                               TraceDataCategory.FUNCTION_RETURN,
-                                                               'sample_compare_integers', bool_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists',
-                                                               17,
-                                                               TraceDataCategory.LOCAL_VARIABLE,
-                                                               'are_elements_equal', bool_type]
-    expected_trace_data.loc[len(expected_trace_data.index)] = ['tests/test_tracer.py', 'sample_compare_two_int_lists',
-                                                               18,
-                                                               TraceDataCategory.FUNCTION_RETURN,
-                                                               'sample_compare_two_int_lists', bool_type]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        10,
+        TraceDataCategory.FUNCTION_ARGUMENT,
+        "list1",
+        list_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        10,
+        TraceDataCategory.FUNCTION_ARGUMENT,
+        "list2",
+        list_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        15,
+        TraceDataCategory.LOCAL_VARIABLE,
+        "i",
+        int_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        15,
+        TraceDataCategory.LOCAL_VARIABLE,
+        "element1",
+        int_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        16,
+        TraceDataCategory.LOCAL_VARIABLE,
+        "element2",
+        int_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_integers",
+        22,
+        TraceDataCategory.FUNCTION_ARGUMENT,
+        "value1",
+        int_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_integers",
+        22,
+        TraceDataCategory.FUNCTION_ARGUMENT,
+        "value2",
+        int_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_integers",
+        24,
+        TraceDataCategory.LOCAL_VARIABLE,
+        "result",
+        bool_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_integers",
+        24,
+        TraceDataCategory.FUNCTION_RETURN,
+        "sample_compare_integers",
+        bool_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        17,
+        TraceDataCategory.LOCAL_VARIABLE,
+        "are_elements_equal",
+        bool_type,
+    ]
+    expected_trace_data.loc[len(expected_trace_data.index)] = [
+        str(pathlib.Path("tests", "test_tracer.py")),
+        "sample_compare_two_int_lists",
+        18,
+        TraceDataCategory.FUNCTION_RETURN,
+        "sample_compare_two_int_lists",
+        bool_type,
+    ]
     expected_trace_data = expected_trace_data.astype(constants.TraceData.SCHEMA)
 
     test_object.start_trace()
@@ -231,7 +278,7 @@ def test_if_tracer_traces_sample_function_with_inner_function_it_collects_correc
     test_object.stop_trace()
 
     actual_trace_data = test_object.trace_data
-    #with pd.option_context("display.max_rows", None, "display.max_columns", None):
+    # with pd.option_context("display.max_rows", None, "display.max_columns", None):
     #    print(actual_trace_data.head(n=20))
     #    print(actual_trace_data.dtypes)
     #    print(expected_trace_data.dtypes)


### PR DESCRIPTION
Removing the while loop in the test code seems to fix the tests not completing. It still successfully runs in the CI.
The path-related issues were fixed by serialising Path objects, which handle the platform-dependent path separators.