### PR TITLE
enhm/pytest-requirements

### DIFF
--- a/tests/typegen/strats/test_inline.py
+++ b/tests/typegen/strats/test_inline.py
@@ -700,7 +700,7 @@ def function(parameter: Clazz):
     def __init__(self):
         self.class_member: int = 5
 
-    def change_value(self, parameter1: int, parameter2: str) -> None:
+    def change_value(self, parameter1: int, parameter2: str) -> bool:
         local_variable = parameter1 == parameter2
         self.class_member: int = int(local_variable)
         return local_variable

--- a/tracing/decorators.py
+++ b/tracing/decorators.py
@@ -29,9 +29,10 @@ def _trace_callable(tracer: TracerBase, call: Callable[..., RetType]) -> str | N
     try:
         with tracer.active_trace():
             call()
+        return None
 
     except:
-        return traceback.print_exc()
+        return traceback.format_exc()
 
 
 def _execute_tracing(

--- a/tracing/decorators.py
+++ b/tracing/decorators.py
@@ -3,10 +3,12 @@ import functools
 import os
 import pathlib
 import inspect
+import traceback
 from typing import Any, Callable, Protocol, TypeVar
 import timeit
 
 import pandas as pd
+from pandas.util import hash_pandas_object
 import numpy as np
 
 import constants
@@ -23,9 +25,13 @@ class _TemplateSubstitutes:
     func_name: str
 
 
-def _trace_callable(tracer: TracerBase, call: Callable[..., RetType]):
-    with tracer.active_trace():
-        call()
+def _trace_callable(tracer: TracerBase, call: Callable[..., RetType]) -> str | None:
+    try:
+        with tracer.active_trace():
+            call()
+
+    except:
+        return traceback.print_exc()
 
 
 def _execute_tracing(
@@ -35,23 +41,7 @@ def _execute_tracing(
     *args,
     **kwargs,
 ) -> tuple[pd.DataFrame, np.ndarray | None]:
-    trace_subst = config.pytypes.output_template.format_map(
-        {
-            "project": subst.project,
-            "test_case": subst.test_case,
-            "func_name": subst.func_name,
-        }
-    )
-
     if config.pytypes.benchmark_performance:
-        benchmark_subst = config.pytypes.output_npy_template.format_map(
-            {
-                "project": subst.project,
-                "test_case": subst.test_case,
-                "func_name": subst.func_name,
-            }
-        )
-
         no_operation_tracer = NoOperationTracer(
             proj_path=config.pytypes.proj_path,
             stdlib_path=config.pytypes.stdlib_path,
@@ -91,6 +81,9 @@ def _execute_tracing(
 
         traced = tracers[-1].trace_data
 
+        # Unable to catch error in benchmarking mode due to timeit usage
+        err = None
+
     else:
         benchmarks = None
 
@@ -101,19 +94,44 @@ def _execute_tracing(
             apply_opts=True,
         )
 
-        _trace_callable(tracer, lambda: c(*args, **kwargs))
+        err = _trace_callable(tracer, lambda: c(*args, **kwargs))
 
         traced = tracer.trace_data
 
     if benchmarks is not None:
-        benchmark_output_path = config.pytypes.proj_path / benchmark_subst
+        # Append hash to avoid overwriting other benchmarks
+        benchmark_subst = config.pytypes.output_npy_template.format_map(
+            {
+                "project": subst.project,
+                "test_case": subst.test_case,
+                "func_name": subst.func_name,
+            }
+        )
+        benchmark_output_path = (
+            config.pytypes.proj_path / f"{benchmark_subst}-{hash(str(benchmarks))}"
+        )
         benchmark_output_path.parent.mkdir(parents=True, exist_ok=True)
         np.save(benchmark_output_path, benchmarks)
 
+    # Append hash to avoid overwriting other pickled DataFrames
+    trace_subst = config.pytypes.output_template.format_map(
+        {
+            "project": subst.project,
+            "test_case": subst.test_case,
+            "func_name": f"{subst.func_name}-{hash_pandas_object(traced).sum()}",
+        }
+    )
+
     trace_output_path = config.pytypes.proj_path / trace_subst
-    print(trace_output_path)
     trace_output_path.parent.mkdir(parents=True, exist_ok=True)
-    traced.to_pickle(str(trace_output_path))
+
+    if err is not None:
+        err_output_path = trace_output_path.with_suffix(".err")
+        err_output_path.open("w").write(err)
+
+    else:
+        print(trace_output_path)
+        traced.to_pickle(str(trace_output_path))
 
     return traced, benchmarks
 
@@ -148,14 +166,7 @@ def trace(c: Callable[..., RetType]) -> _Traceable:
 
     @functools.wraps(c)
     def wrapper(*args, **kwargs) -> tuple[pd.DataFrame, np.ndarray | None]:
-        root = pathlib.Path.cwd()
-        cfg = ptconfig.load_config(root / constants.CONFIG_FILE_NAME)
-        if cfg.pytypes.proj_path != root:
-            raise RuntimeError(
-                f"Invalid config file: wrong project root: {trace.__name__} had \
-                {root} specified, config file has {cfg.pytypes.proj_path} set"
-            )
-
+        cfg = ptconfig.load_config(pathlib.Path(constants.CONFIG_FILE_NAME))
         subst = _TemplateSubstitutes(
             project=cfg.pytypes.project,
             test_case=module_name,

--- a/tracing/decorators.py
+++ b/tracing/decorators.py
@@ -131,7 +131,6 @@ def _execute_tracing(
         err_output_path.open("w").write(err)
 
     else:
-        print(trace_output_path)
         traced.to_pickle(str(trace_output_path))
 
     return traced, benchmarks

--- a/tracing/optimisation/looping.py
+++ b/tracing/optimisation/looping.py
@@ -28,7 +28,7 @@ class TypeStableLoop(Optimisation):
         self._iterations_since_type_changes = 0
         self._status = TriggerStatus.INACTIVE
 
-        self._relevant_lines: tuple[int, int | None] = (self.fwm.f_lineno, None)
+        self._relevant_lines: tuple[int, int] = (self.fwm.f_lineno, self.fwm.f_lineno)
         self._loop_traced_count = 0
 
     def status(self) -> TriggerStatus:
@@ -71,7 +71,7 @@ class TypeStableLoop(Optimisation):
             self._when_ongoing(current_frame, traced)
             self._status = TriggerStatus.ONGOING
 
-        if self._relevant_lines[1] and current_frame.f_lineno > self._relevant_lines[1]:
+        if current_frame.f_lineno > self._relevant_lines[1]:
             logger.debug(
                 f"{TypeStableLoop.__name__}: {self._status} -> EXITED due to leaving loop"
             )

--- a/tracing/resolver.py
+++ b/tracing/resolver.py
@@ -110,6 +110,13 @@ class Resolver:
         if module.__name__ == "builtins":
             return None, ty.__name__
 
+        # Special case:
+        # The __file__ attribute is not present for C modules that are statically linked into the interpreter; 
+        # for extension modules loaded dynamically from a shared library, 
+        # it is the pathname of the shared library file.
+        if not hasattr(module, "__file__"):
+            return module.__name__, ty.__name__
+
         assert module.__file__ is not None
         module_file = pathlib.Path(module.__file__)
 

--- a/tracing/resolver.py
+++ b/tracing/resolver.py
@@ -6,7 +6,7 @@ import logging
 import os
 import pathlib
 import sys
-from types import ModuleType
+from types import ModuleType, NoneType
 
 import pandas as pd
 
@@ -70,6 +70,9 @@ class Resolver:
         logger.debug(f"{(module_name, type_name)} as builtin?")
         if not isinstance(module_name, str):
             # __builtins__ is typed as Module by mypy, but is dict in the REPL?
+            # Special case: NoneType
+            if type_name == "NoneType":
+                return NoneType
             builtin_ty: type = __builtins__[type_name]  # type: ignore
             return builtin_ty
 

--- a/tracing/tracer.py
+++ b/tracing/tracer.py
@@ -28,10 +28,11 @@ logger = logging.getLogger(__name__)
 
 class TracerBase(abc.ABC):
     def __init__(
-            self,
-            proj_path: pathlib.Path,
-            stdlib_path: pathlib.Path,
-            venv_path: pathlib.Path):
+        self,
+        proj_path: pathlib.Path,
+        stdlib_path: pathlib.Path,
+        venv_path: pathlib.Path,
+    ):
         self.trace_data = pd.DataFrame(columns=constants.TraceData.SCHEMA).astype(
             constants.TraceData.SCHEMA
         )
@@ -49,7 +50,11 @@ class TracerBase(abc.ABC):
         self._prev_line: list[int] = list()
 
         self.class_names_to_drop = [TracerBase.__name__]
-        self.function_names_to_drop = [self.stop_trace.__name__, self.start_trace.__name__, self.active_trace.__name__]
+        self.function_names_to_drop = [
+            self.stop_trace.__name__,
+            self.start_trace.__name__,
+            self.active_trace.__name__,
+        ]
 
     def start_trace(self) -> None:
         """Starts the trace."""
@@ -74,7 +79,9 @@ class TracerBase(abc.ABC):
 
         drop_masks = [
             self.trace_data[constants.TraceData.CLASS].isin(self.class_names_to_drop),
-            self.trace_data[constants.TraceData.FUNCNAME].isin(self.function_names_to_drop),
+            self.trace_data[constants.TraceData.FUNCNAME].isin(
+                self.function_names_to_drop
+            ),
         ]
         td_drop = self.trace_data[functools.reduce(operator.and_, drop_masks)]
         self.trace_data = self.trace_data.drop(td_drop.index)


### PR DESCRIPTION
Collection of small tweaks needed to get more projects up and running, as well as QoL improvements, such as: 

- supporting `requirements.txt` and  `requirements-dev.txt`
- shallow git clones that use SSH
- avoiding overwriting trace data of tests using `@pytest.parametrize`
- logging tracebacks of failed executions to `.err` files
- preferring to hint with None instead of NoneType