### PR TITLE
Restore trace hook previously set

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = ./.venv/*,*tests*,*__init__.py,main.py,examples
+omit = ./.venv/*,*tests*,*__init__.py,main.py,examples,tracing/*

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -68,5 +68,6 @@ jobs:
         poetry run python -m coverage run --source=. -m pytest --ignore=tests/tracing
         poetry run python -m coverage report -m
 
-    - name: sys.settrace + pytest (cannot be covered)
+    - name: settrace + pytest
+      run: | 
         poetry run python -m pytest tests/tracing

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -62,12 +62,12 @@ jobs:
       run: |
         poetry run mypy .
 
-    - name: coverage + pytest
+    - name: PyTest + coverage
       run: |
         poetry run python main.py confgen -p .
         poetry run python -m coverage run --source=. -m pytest --ignore=tests/tracing
         poetry run python -m coverage report -m
 
-    - name: settrace + pytest
+    - name: PyTest + sys.settrace
       run: | 
         poetry run python -m pytest tests/tracing

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -62,8 +62,11 @@ jobs:
       run: |
         poetry run mypy .
 
-    - name: Test with pytest
+    - name: coverage + pytest
       run: |
         poetry run python main.py confgen -p .
-        poetry run python -m coverage run --source=. -m pytest
+        poetry run python -m coverage run --source=. -m pytest --ignore=tests/tracing
         poetry run python -m coverage report -m
+
+    - name: sys.settrace + pytest (cannot be covered)
+        poetry run python -m pytest tests/tracing

--- a/tracing/tracer.py
+++ b/tracing/tracer.py
@@ -56,9 +56,12 @@ class TracerBase(abc.ABC):
             self.active_trace.__name__,
         ]
 
+        self._old_trace: typing.Callable | None = None
+
     def start_trace(self) -> None:
         """Starts the trace."""
         logger.info("Starting trace")
+        self._old_trace = sys.gettrace()
         sys.settrace(self._on_trace_is_called)
         self._prev_line.clear()
 
@@ -72,7 +75,7 @@ class TracerBase(abc.ABC):
 
     def stop_trace(self):
         logger.info("Stopping trace")
-        sys.settrace(None)
+        sys.settrace(self._old_trace)
 
         # Drop all references to the tracer
         self.trace_data = self.trace_data.drop_duplicates(ignore_index=True)


### PR DESCRIPTION
Otherwise, anything that uses coverage, pdb will not work after tracing.
NOTE: https://coverage.readthedocs.io/en/latest/trouble.html

Coverage results will still be influenced simply by using `sys.settrace`